### PR TITLE
Don't treat errors as data objects

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -98,7 +98,7 @@ define( function( require, exports, module ){
       var data = utils.extend( {}, this.options.data );
 
       args.filter( function( a ){
-        return typeof a === 'object' && !Array.isArray( a );
+        return typeof a === 'object' && !Array.isArray( a ) && !(a instanceof Error);
       }).forEach( function( a ){
         utils.extend( data, a );
       });


### PR DESCRIPTION
Handy for situations where you want to `log.warn('blahblah', error)`
